### PR TITLE
表單中填寫物資與捐贈者資料步驟增加記憶功能

### DIFF
--- a/src/component/Form.js
+++ b/src/component/Form.js
@@ -19,7 +19,7 @@ import map from 'lodash/map';
 import merge from 'lodash/merge';
 
 import { getTaipeiStationEvents } from '../api/events';
-import { getDonationInputs } from '../form-helper';
+import { getCachedInputsByKey, DONATION_INPUT_KEY } from '../form-helper';
 
 let fieldValues ={
   locationId: '',
@@ -46,7 +46,7 @@ class Form extends React.Component {
   constructor(props) {
     super(props);
     // Get last saved donations inputs
-    const content = getDonationInputs()
+    const content = getCachedInputsByKey(DONATION_INPUT_KEY);
     if (content) {
       fieldValues.items[0].content = content
     }

--- a/src/component/Form.js
+++ b/src/component/Form.js
@@ -19,6 +19,7 @@ import map from 'lodash/map';
 import merge from 'lodash/merge';
 
 import { getTaipeiStationEvents } from '../api/events';
+import { getDonationInputs } from '../form-helper';
 
 let fieldValues ={
   locationId: '',
@@ -42,6 +43,14 @@ function getSteps() {
 
 
 class Form extends React.Component {
+  constructor(props) {
+    super(props);
+    // Get last saved donations inputs
+    const content = getDonationInputs()
+    if (content) {
+      fieldValues.items[0].content = content
+    }
+  }
 
   state = {
     activeStep: 0,

--- a/src/component/GetInfo.js
+++ b/src/component/GetInfo.js
@@ -299,7 +299,8 @@ class GetInfo extends React.Component {
               <div className="info">
                 <h2>電子信箱</h2>
                 <input
-                  type="text"
+                  type="email"
+                  autoComplete="email"
                   ref="email"
                   placeholder="電子信箱"
                   className="more-width"
@@ -311,7 +312,8 @@ class GetInfo extends React.Component {
               <div className="info">
                 <h2>電話</h2>
                 <input
-                  type="text"
+                  type="tel"
+                  autoComplete="tel"
                   ref="phone"
                   placeholder="電話"
                   value={this.state.phone}

--- a/src/component/GetInfo.js
+++ b/src/component/GetInfo.js
@@ -8,6 +8,8 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { withStyles } from '@material-ui/core/styles';
 
 import validator from 'validator';
@@ -16,6 +18,7 @@ import map from 'lodash/map';
 import { GIVER_TYPES, CONTACT_TITLES } from '../const';
 
 import { Link as Rlink} from 'react-router-dom';
+import * as helper from "../form-helper";
 
 
 const styles = {
@@ -32,8 +35,8 @@ const styles = {
   }
 };
 
-const getDefaultState = () => {
-  return {
+const getDefaultState = ( giver ) => {
+  const defaultState =  {
     openCancelDialog: false,
     type: 'person',
     name: '',
@@ -43,7 +46,17 @@ const getDefaultState = () => {
     phone: '',
     open: false,
     errors: [],
+    isInfoRemembered: false,
   };
+
+  if (isPropsGiverUsable(giver)) {
+    return Object.assign({}, defaultState, giver);
+  } else if (helper.getContactInfo()) {
+    return helper.getContactInfo();
+  } else {
+    return defaultState;
+  }
+
 };
 
 const isPropsGiverUsable = (propGiver) => {
@@ -54,13 +67,18 @@ class GetInfo extends React.Component {
   constructor(props) {
     super(props);
     const { giver } = this.props.fieldValues;
-    this.state = isPropsGiverUsable(giver) ? {...getDefaultState(), ...giver} : getDefaultState();
+    this.state = getDefaultState(giver);
+
     this.nextStep = this.nextStep.bind(this);
     this.changeType = this.changeType.bind(this);
     this.validate = this.validate.bind(this);
     this.handleClose = this.handleClose.bind(this);
     this.handleCancelDialogOpen = this.handleCancelDialogOpen.bind(this);
     this.handleCancelDialogClose = this.handleCancelDialogClose.bind(this);
+  }
+
+  componentWillUnmount() {
+    this.handleRememberInputs();
   }
 
   validate() {
@@ -169,6 +187,21 @@ class GetInfo extends React.Component {
     this.setState({openCancelDialog: false});
   }
 
+  handleMemorizeChkBoxChange = (e) => {
+    this.setState({
+      isInfoRemembered: e.target.checked,
+    });
+  };
+
+  handleRememberInputs = () => {
+    // save inputs if checkbox is checked; remove stored data if unchecked
+    if (this.state.isInfoRemembered) {
+      helper.saveContactInfo(this.state)
+    } else {
+      helper.removeContactInfo()
+    }
+  };
+
   render() {
     return (
       <div>
@@ -260,6 +293,19 @@ class GetInfo extends React.Component {
               </div>
             </div>
           </div>
+        </div>
+        <div>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={this.state.isInfoRemembered}
+                onChange={this.handleMemorizeChkBoxChange}
+                value="remembered"
+                color="primary"
+              />
+            }
+            label="記住我的聯絡資訊"
+          />
         </div>
         {/* 按鈕 */}
         <Grid container direction="row" justify="space-between">

--- a/src/component/GetInfo.js
+++ b/src/component/GetInfo.js
@@ -48,11 +48,13 @@ const getDefaultState = ( giver ) => {
     errors: [],
     isInfoRemembered: false,
   };
+  const cachedGiver = helper.getCachedInputsByKey(helper.CONTACT_INFO_KEY);
+  const checkBoxState = { isInfoRemembered: Boolean(cachedGiver)};
 
   if (isPropsGiverUsable(giver)) {
-    return Object.assign({}, defaultState, giver);
-  } else if (helper.getContactInfo()) {
-    return helper.getContactInfo();
+    return Object.assign({}, defaultState, giver, checkBoxState);
+  } else if (cachedGiver) {
+    return Object.assign({}, defaultState, cachedGiver, checkBoxState);
   } else {
     return defaultState;
   }
@@ -134,6 +136,32 @@ class GetInfo extends React.Component {
     }
   }
 
+  handlePrevStepClick = (e) => {
+    e.preventDefault();
+    this.props.saveGiverValues(this.extractGiverValues());
+    this.props.handleBack();
+  };
+
+  extractGiverValues = () => {
+    const {
+      type,
+      name,
+      contactName,
+      contactTitle,
+      email,
+      phone,
+    } = this.state;
+
+    return  {
+      type: type,
+      name: type === 'person' ? contactName : name,
+      contactName,
+      contactTitle,
+      email,
+      phone,
+    };
+  };
+
   changeType(event) {
     event.preventDefault();
 
@@ -196,9 +224,9 @@ class GetInfo extends React.Component {
   handleRememberInputs = () => {
     // save inputs if checkbox is checked; remove stored data if unchecked
     if (this.state.isInfoRemembered) {
-      helper.saveContactInfo(this.state)
+      helper.saveContactInfo(this.extractGiverValues());
     } else {
-      helper.removeContactInfo()
+      helper.removeCachedInputsByKey(helper.CONTACT_INFO_KEY);
     }
   };
 
@@ -309,7 +337,7 @@ class GetInfo extends React.Component {
         </div>
         {/* 按鈕 */}
         <Grid container direction="row" justify="space-between">
-          <Button variant="outlined" onClick={this.props.handleBack} className="formbutton-back">
+          <Button variant="outlined" onClick={this.handlePrevStepClick} className="formbutton-back">
             <i className="fas fa-arrow-left"></i>
             上一步</Button>
           <Hidden smUp>

--- a/src/component/GetItem.js
+++ b/src/component/GetItem.js
@@ -8,12 +8,17 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { withStyles } from '@material-ui/core/styles';
 
 import map from 'lodash/map';
 import some from 'lodash/some';
 
 import { Link as Rlink} from 'react-router-dom';
+
+import * as helper from '../form-helper';
+import GetStepContent from "./GetStepContent";
 
 const styles = {
   confirmButton: {
@@ -41,14 +46,18 @@ class GetItem extends React.Component {
       openCancelDialog:false,
       content: contentProp.length ? contentProp : getDefaultContentArray(),
       open: false,
+      isInputRemembered: Boolean(helper.getDonationInputs()),
     };
-    this.nextStep = this.nextStep.bind(this);
   }
-    
+
+  componentWillUnmount() {
+    this.handleRememberInputs()
+  }
+
   handleAddContent = () => {
     this.setState({ content: this.state.content.concat(getDefaultContentArray()) });
   }
-  
+
   handleRemoveContent = (idx) => () => {
     this.setState({ content: this.state.content.filter((element,indexbeselced) => idx !== indexbeselced) });
   }
@@ -68,7 +77,7 @@ class GetItem extends React.Component {
     });
   };
 
-  nextStep(event) {
+  nextStep = (event) => {
     event.preventDefault();
 
     const data = this.state.content;
@@ -91,7 +100,21 @@ class GetItem extends React.Component {
     this.setState({ openCancelDialog: false });
   }
 
-  render() {    
+  handleMemorizeInputCheckboxChange = (e) => {
+    const { checked } = e.target
+    this.setState({ isInputRemembered : checked })
+  };
+
+  handleRememberInputs = () => {
+    // save inputs if checkbox is checked; remove stored data if unchecked
+    if (this.state.isInputRemembered) {
+      helper.saveDonationInputs(this.state.content)
+    } else {
+      helper.removeDonationInputs()
+    }
+  };
+
+  render() {
     return (
       <div>
         <div className="form-frame">
@@ -149,16 +172,16 @@ class GetItem extends React.Component {
                       />
                       <Hidden smDown>
                         <button type="button" onClick={this.handleAddContent}>+</button>
-                        {this.state.content.length > 1 ? 
+                        {this.state.content.length > 1 ?
                           <button type="button" onClick={this.handleRemoveContent(idx)}>-</button> : null
-                        }      
+                        }
                       </Hidden>
                     </Grid>
                     <Grid container direction="row" justify="space-between">
                       <button type="button" onClick={this.handleAddContent} className="hidden-md">
                         + 新增項目
                       </button>
-                      {this.state.content.length > 1 ? 
+                      {this.state.content.length > 1 ?
                         <button type="button" onClick={this.handleRemoveContent(idx)} className="hidden-md">
                         - 刪除項目
                         </button> : null}
@@ -168,10 +191,23 @@ class GetItem extends React.Component {
             </div>
             </div>
           </div>
+          <div>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={this.state.isInputRemembered}
+                  onChange={this.handleMemorizeInputCheckboxChange}
+                  value="remembered"
+                  color="primary"
+                />
+              }
+              label="記住我的輸入"
+            />
+          </div>
           {/* 按鈕 */}
           <Grid container direction="row" justify="space-between">
             <Button variant="outlined" onClick={this.props.handleBack} className="formbutton-back">
-              <i className="fas fa-arrow-left"></i> 
+              <i className="fas fa-arrow-left"></i>
               上一步</Button>
             <Hidden smUp>
               <div className="cancle-log" onClick={this.handleCancelDialogOpen}>取消登記</div>
@@ -242,6 +278,11 @@ GetItem.propTypes = {
       content: PropTypes.array,
     }),
   }).isRequired,
+  saveDateValues: PropTypes.func,
+  saveContentValues: PropTypes.func,
+  saveGiverValues: PropTypes.func,
+  handleNext: PropTypes.func,
+  handleBack: PropTypes.func,
 };
 
 export default withStyles(styles)(GetItem);

--- a/src/component/GetItem.js
+++ b/src/component/GetItem.js
@@ -18,7 +18,6 @@ import some from 'lodash/some';
 import { Link as Rlink} from 'react-router-dom';
 
 import * as helper from '../form-helper';
-import GetStepContent from "./GetStepContent";
 
 const styles = {
   confirmButton: {
@@ -34,19 +33,15 @@ const styles = {
   }
 };
 
-const getDefaultContentArray = () => (
-  [{ name: '', amount: '', description: '' }]
-);
-
 class GetItem extends React.Component {
   constructor(props) {
     super(props);
     const contentProp = this.props.fieldValues.items[0].content;
     this.state = {
       openCancelDialog:false,
-      content: contentProp.length ? contentProp : getDefaultContentArray(),
+      content: contentProp.length ? contentProp : helper.getDefaultContentArray(),
       open: false,
-      isInputRemembered: Boolean(helper.getDonationInputs()),
+      isInputRemembered: Boolean(helper.getCachedInputsByKey(helper.DONATION_INPUT_KEY)),
     };
   }
 
@@ -55,7 +50,8 @@ class GetItem extends React.Component {
   }
 
   handleAddContent = () => {
-    this.setState({ content: this.state.content.concat(getDefaultContentArray()) });
+    const newContent = this.state.content.concat(helper.getDefaultContentArray());
+    this.setState({ content: newContent });
   }
 
   handleRemoveContent = (idx) => () => {
@@ -110,7 +106,7 @@ class GetItem extends React.Component {
     if (this.state.isInputRemembered) {
       helper.saveDonationInputs(this.state.content)
     } else {
-      helper.removeDonationInputs()
+      helper.removeCachedInputsByKey(helper.DONATION_INPUT_KEY);
     }
   };
 
@@ -136,7 +132,7 @@ class GetItem extends React.Component {
                 </Grid>
               </Hidden>
                 {this.state.content.map((content, idx) => (
-                  <Grid container direction='row' className="item-list">
+                  <Grid key={idx} container direction='row' className="item-list">
                     <Grid item xs={12} md={4} className="item">
                       <h2 className="hidden-md">項目</h2>
                       <input

--- a/src/form-helper.js
+++ b/src/form-helper.js
@@ -1,4 +1,5 @@
 const DONATION_INPUT_KEY = 'donations';
+const CONTACT_INFO_KEY = 'contacts';
 
 export const getDonationInputs = () => {
   if (window) {
@@ -24,5 +25,29 @@ export const saveDonationInputs = (content) => {
 export const removeDonationInputs = () => {
   if (window) {
     window.localStorage.removeItem(DONATION_INPUT_KEY)
+  }
+};
+
+export const getContactInfo = () => {
+  if (window) {
+    const info = window.localStorage.getItem(CONTACT_INFO_KEY);
+
+    if (info) {
+      return JSON.parse(info);
+    }
+  }
+
+  return undefined;
+};
+
+export const saveContactInfo = (info) => {
+  if (window) {
+    window.localStorage.setItem(CONTACT_INFO_KEY, JSON.stringify(info));
+  }
+};
+
+export const removeContactInfo = () => {
+  if (window) {
+    window.localStorage.removeItem(CONTACT_INFO_KEY)
   }
 };

--- a/src/form-helper.js
+++ b/src/form-helper.js
@@ -1,17 +1,11 @@
-const DONATION_INPUT_KEY = 'donations';
-const CONTACT_INFO_KEY = 'contacts';
+export const DONATION_INPUT_KEY = 'donations';
+export const CONTACT_INFO_KEY = 'contacts';
 
-export const getDonationInputs = () => {
-  if (window) {
-    const content = window.localStorage.getItem(DONATION_INPUT_KEY)
+const KEYS = [
+  DONATION_INPUT_KEY,
+  CONTACT_INFO_KEY,
+];
 
-    if (content) {
-      return JSON.parse(content);
-    }
-  }
-
-  return undefined;
-};
 
 export const saveDonationInputs = (content) => {
   if (window) {
@@ -22,32 +16,38 @@ export const saveDonationInputs = (content) => {
   }
 };
 
-export const removeDonationInputs = () => {
-  if (window) {
-    window.localStorage.removeItem(DONATION_INPUT_KEY)
-  }
-};
-
-export const getContactInfo = () => {
-  if (window) {
-    const info = window.localStorage.getItem(CONTACT_INFO_KEY);
-
-    if (info) {
-      return JSON.parse(info);
-    }
-  }
-
-  return undefined;
-};
-
 export const saveContactInfo = (info) => {
   if (window) {
     window.localStorage.setItem(CONTACT_INFO_KEY, JSON.stringify(info));
   }
 };
 
-export const removeContactInfo = () => {
+export const removeCachedInputsByKey = (key) => {
+  if (typeof key !== 'string' || !KEYS.includes(key)) {
+    throw new Error(`invalid key: ${key}. Must be a string and is one of ${KEYS.toString()}`)
+  }
+
   if (window) {
-    window.localStorage.removeItem(CONTACT_INFO_KEY)
+    window.localStorage.removeItem(key)
   }
 };
+
+export const getCachedInputsByKey = (key) => {
+  if (typeof key !== 'string' || !KEYS.includes(key)) {
+    throw new Error(`invalid key: ${key}. Must be a string and is one of ${KEYS.toString()}`)
+  }
+
+  if (window) {
+    const data = window.localStorage.getItem(key);
+
+    if (data) {
+      return JSON.parse(data);
+    }
+  }
+
+  return undefined;
+};
+
+export const getDefaultContentArray = () => (
+  [{ name: '', amount: '', description: '' }]
+);

--- a/src/form-helper.js
+++ b/src/form-helper.js
@@ -1,0 +1,28 @@
+const DONATION_INPUT_KEY = 'donations';
+
+export const getDonationInputs = () => {
+  if (window) {
+    const content = window.localStorage.getItem(DONATION_INPUT_KEY)
+
+    if (content) {
+      return JSON.parse(content);
+    }
+  }
+
+  return undefined;
+};
+
+export const saveDonationInputs = (content) => {
+  if (window) {
+    const isNonEmpty = obj => Object.values(obj).some(val => Boolean(val));
+    const result = content.filter(isNonEmpty);
+
+    window.localStorage.setItem(DONATION_INPUT_KEY, JSON.stringify(result));
+  }
+};
+
+export const removeDonationInputs = () => {
+  if (window) {
+    window.localStorage.removeItem(DONATION_INPUT_KEY)
+  }
+};


### PR DESCRIPTION
Fix #43 .
登記發放物資的表單中，增加記憶功能，
讓使用者下次再次填寫時可以帶入之前填的資訊，
增加使用者的方便度。

1. 修正 Step 3 「捐贈者資料」頁面按 `上一步`，再按「下一步」回來時，原本填寫的資料被清空
2. Step 2「物資」增加 `記住我的輸入`選項
3. Step 3「捐贈者資料」增加 `記住我的聯絡資訊`選項

Checkbox 打勾時，在離開頁面時會寫入 cache，若取消打勾，則會將 cache 的資料移除。